### PR TITLE
update terra.js lcd instantiation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ import { LCDClient } from "@terra-money/terra.js";
 
 const terra = new LCDClient({
   URL: "http://localhost:1317",
-  chainId: "localterra",
+  chainID: "localterra",
 });
 ```
 


### PR DESCRIPTION
There is a small typo in the README tutorial to init LocalTerra with Terra.js